### PR TITLE
Fix Deployment Errors

### DIFF
--- a/incubator/scylladb/templates/statefulset.yaml
+++ b/incubator/scylladb/templates/statefulset.yaml
@@ -60,7 +60,7 @@ spec:
           - --seeds
           - {{ template "scylladb.fullname" . }}-0.{{ template "scylladb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
           {{- if .Values.config.overprovisioned }}
-          - --overprovisioned
+          - --overprovisioned=1
           {{- end }}
           {{- if .Values.config.cpu }}
           - --smp
@@ -84,27 +84,20 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 5
         volumeMounts:
-          - name: scylla-conf-yaml
+          - name: scylla-files
             mountPath: /etc/scylla/scylla.yaml
-          - name: scylla-ready-probe
+            subPath: scylla.yaml
+          - name: scylla-files
             mountPath: /opt/ready-probe.sh
+            subPath: ready-probe.sh
           {{- if .Values.persistence.size }}
           - name: datadir
             mountPath: /var/lib/scylla
           {{- end }}
       volumes:
-        - name: scylla-ready-probe
+        - name: scylla-files
           configMap:
             name: {{ template "scylladb.fullname" . }}
-            items:
-            - key: ready-probe.sh
-              path: ready-probe.sh
-        - name: scylla-conf-yaml
-          configMap:
-            name: scylla
-            items:
-            - key: scylla.yaml
-              path: scylla.yaml
   volumeClaimTemplates:
     - metadata:
         name: datadir

--- a/incubator/scylladb/values.yaml
+++ b/incubator/scylladb/values.yaml
@@ -52,4 +52,4 @@ affinity: {}
 
 persistence:
   accessMode: ReadWriteOnce
-  size: 15Gi
+  size: 1Gi


### PR DESCRIPTION
This commit fixes, and cleans up, the mount points for the probes. It also
sets the default volume to 1Gi, which is the default across most other Helm
charts; as this value is expected to be provided during a production deployment.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
